### PR TITLE
2016-11-22, Version 7.2.0 (Current)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OpenEmbedded layer for latest [Node.js](https://nodejs.org/ "Node.js") releases.
 
 ## Node.js releases
 
- * ![Current 7](https://img.shields.io/badge/Node.js%20Current-7.1.0-green.svg)
+ * ![Current 7](https://img.shields.io/badge/Node.js%20Current-7.2.0-green.svg)
  * ![LTS 6](https://img.shields.io/badge/Node.js%20LTS-6.9.1-blue.svg)
  * ![LTS 4](https://img.shields.io/badge/Node.js%20LTS-4.6.2-blue.svg)
  * ![Maintenance 0.12](https://img.shields.io/badge/Node.js%20Maintenance-0.12.17-lightgray.svg)

--- a/recipes-devtools/nodejs/nodejs_7.1.0.bb
+++ b/recipes-devtools/nodejs/nodejs_7.1.0.bb
@@ -1,8 +1,0 @@
-require nodejs_7.inc
-
-INC_PR = "r1"
-
-LIC_FILES_CHKSUM = "file://LICENSE;md5=41a3a0ccf7f515cac3377389dd8faac8"
-
-SRC_URI[src.md5sum] = "1db5df2cb025f9c70e83d9cf21c4266a"
-SRC_URI[src.sha256sum] = "595e7e2a37d1e0573044a90077bb12c0f750e5d8851899ffa74038238da9a983"

--- a/recipes-devtools/nodejs/nodejs_7.2.0.bb
+++ b/recipes-devtools/nodejs/nodejs_7.2.0.bb
@@ -1,0 +1,8 @@
+require nodejs_7.inc
+
+INC_PR = "r1"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=41a3a0ccf7f515cac3377389dd8faac8"
+
+SRC_URI[src.md5sum] = "ea2dd2de3e93b601f576bf24c1ab56ec"
+SRC_URI[src.sha256sum] = "c3f53a5d8cea145e25706bb21cdac62f1b3314db35785bcf468558a29cfc352f"


### PR DESCRIPTION
This is a security release impacting Windows 10 users.

    Notable changes:

    * crypto: The `Decipher` methods `setAuthTag()` and `setAAD` now return
    `this`. (Kirill Fomichev) https://github.com/nodejs/node/pull/9398
    * dns: Implemented `{ttl: true}` for `resolve4()` and `resolve6()`.
    (Ben Noordhuis) https://github.com/nodejs/node/pull/9296 &
    https://github.com/nodejs/node/pull/9296
    * libuv: Upgrade to v1.10.1 (cjihrig)
    https://github.com/nodejs/node/pull/9647
      - Fixed a potential buffer overflow when writing data to console on
    Windows 10. (CVE-2016-9551)
    * process: Added a new `external` property to the data returned by
    `memoryUsage()`. (Fedor Indutny)
    https://github.com/nodejs/node/pull/9587
    * tls: Fixed a memory leak when writes were queued on TLS connection
    that was destroyed during handshake. (Fedor Indutny)
    https://github.com/nodejs/node/pull/9626
    * V8 (dep): Upgrade to v5.4.500.43 (Michaël Zasso)
    https://github.com/nodejs/node/pull/9697
    * v8: The data returned by `getHeapStatistics()` now includes three new
    fields: `malloced_memory`, `peak_malloced_memory`, and
    `does_zap_garbage`. (Gareth Ellis)
    https://github.com/nodejs/node/pull/8610

Signed-off-by: Ilkka Myller <ilkka.myller@nodefield.com>